### PR TITLE
Modified projectile destroy

### DIFF
--- a/Assets/Character/Attack/PlayerAttack.cs
+++ b/Assets/Character/Attack/PlayerAttack.cs
@@ -8,7 +8,7 @@ namespace Character.Attack
         [SerializeField] private GameObject _projectilePrefab;
         [SerializeField] private Transform _projectileSpawn;
 
-        private float _atkSpeed = 0.3f;
+        private float _atkSpeed = 0.1f;
         private float _coolDown = 0;
         private bool _isShooting;
 

--- a/Assets/Character/Attack/PlayerProjectile.cs
+++ b/Assets/Character/Attack/PlayerProjectile.cs
@@ -6,25 +6,38 @@ namespace Character.Attack
     public class PlayerProjectile : MonoBehaviour
     {
         private float _speed = 50f;
+        private Transform _myTransform;
+        private Camera _cam;
 
-        private float _timerTest = 0;
+        private Vector2 _minBound;
+        private Vector2 _maxBound;
+
+        private void Awake()
+        {
+            _myTransform = transform;
+            _cam = Camera.main;
+
+            _minBound = _cam.ViewportToWorldPoint(new Vector2(0, 0));
+            _maxBound = _cam.ViewportToWorldPoint(new Vector2(1, 1));
+        }
 
         private void Update()
         {
             ProjectileMovement();
-
-            _timerTest += Time.deltaTime;
-
-            if (_timerTest > 3f)
-            {
-                _timerTest = 0;
-                ProjectilePoolManager.ReturnObjectPool(gameObject);
-            }
+            ProjectileDestroy();
         }
 
         public void ProjectileMovement()
         {
-            transform.position += Vector3.up * _speed * Time.deltaTime;
+            _myTransform.position += Vector3.up * _speed * Time.deltaTime;
+        }
+
+        public void ProjectileDestroy()
+        {
+            if (_myTransform.position.y < _minBound.y || _myTransform.position.y > _maxBound.y)
+            {
+                ProjectilePoolManager.ReturnObjectPool(gameObject);
+            }
         }
     }
 }

--- a/Assets/Character/Movement/PlayerMovement.cs
+++ b/Assets/Character/Movement/PlayerMovement.cs
@@ -6,8 +6,22 @@ namespace Character.Movement
     {
         [SerializeField] private float _speed = 10f;
 
+        private Transform _myTransform;
         private Vector2 _direction = Vector2.zero;
         private bool _isMoving = false;
+
+        private Camera _cam;
+        private Vector2 _minBound;
+        private Vector2 _maxBound;
+
+        private void Awake()
+        {
+            _myTransform = transform;
+            _cam = Camera.main;
+
+            _minBound = _cam.ViewportToWorldPoint(new Vector2(0, 0));
+            _maxBound = _cam.ViewportToWorldPoint(new Vector2(1, 1));
+        }
 
         private void Update()
         {
@@ -18,8 +32,9 @@ namespace Character.Movement
         {
             if (_isMoving)
             {
-                transform.position += new Vector3(_direction.x, _direction.y) * _speed * Time.deltaTime;
+                _myTransform.position += new Vector3(_direction.x, _direction.y) * _speed * Time.deltaTime;
             }
+            _myTransform.position = new Vector3(Mathf.Clamp(_myTransform.position.x, _minBound.x, _maxBound.x), Mathf.Clamp(_myTransform.position.y, _minBound.y, _maxBound.y));
         }
 
         public void SetMovement(Vector2 direction, bool isMoving)


### PR DESCRIPTION
A projectile is deactivated when touching the top boundary of the camera. The player shoot faster.
The player position is clamped inside the boundary of the camera.